### PR TITLE
Remove `Handler::reset()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 - `Innmind\Signals\Handler` constructor is now private, use `::main()` instead
 - Requires `innmind/immutable:~5.18`
 
+### Removed
+
+- `Innmind\Signals\Handler::reset()`
+
 ## 3.1.0 - 2023-09-23
 
 ### Added

--- a/tests/HandlerTest.php
+++ b/tests/HandlerTest.php
@@ -86,37 +86,6 @@ class HandlerTest extends TestCase
         $this->assertSame(['second'], $order);
     }
 
-    public function testListenersAddedAfterAResetAreNotCalled()
-    {
-        $wasAsync = \pcntl_async_signals();
-        $handlers = Handler::main();
-        $order = [];
-        $count = 0;
-
-        $this->fork();
-
-        $listener = static function($signal) use (&$order, &$count): void {
-            $order[] = 'first';
-            ++$count;
-        };
-        $handlers->listen(Signal::child, $listener);
-
-        $this->assertNull($handlers->reset());
-        $this->assertSame($wasAsync, \pcntl_async_signals());
-
-        try {
-            $handlers->listen(Signal::child, $listener);
-            $this->fail('it should throw');
-        } catch (\Exception $e) {
-            $this->assertInstanceOf(\LogicException::class, $e);
-        }
-
-        \sleep(2); // wait for child to stop
-
-        $this->assertSame(0, $count);
-        $this->assertSame([], $order);
-    }
-
     public function testDefaultHandlerRestoredWhenAllListenersRemovedForASignal()
     {
         $wasAsync = \pcntl_async_signals();


### PR DESCRIPTION
This was useful when `innmind/operating-system` allowed to fork the current process. This feature is no longer available.

This is replaced by async code (see `innmind/async`).